### PR TITLE
Allow non-ASCII characters in shortcut AppName.

### DIFF
--- a/pysteam/_shortcut_generator.py
+++ b/pysteam/_shortcut_generator.py
@@ -49,7 +49,7 @@ class ShortcutGenerator(object):
     # supposed to end in x00 when there are more and x08 when there arent. Since
     # I am not sure, I am going to leave the code in for now
     def generate_keyvalue_pair(self,key,value,more=True):
-        return x01 + key + x00 + value + (x00 if more else x08)
+        return x01 + key + x00 + value.decode("raw_unicode_escape") + (x00 if more else x08)
 
     def generate_tags_string(self,tags):
         string = x00 + "tags" + x00

--- a/pysteam/shortcuts.py
+++ b/pysteam/shortcuts.py
@@ -29,7 +29,7 @@ def read_shortcuts(path):
 def write_shortcuts(path, shortcuts):
   vdf_contents = ShortcutGenerator().to_string(shortcuts)
   with open(path, "w") as f:
-    f.write(vdf_contents)
+    f.write(vdf_contents.encode("raw_unicode_escape"))
 
 # Helper functions which simply wrap the read/write shortcuts functions around
 # the LocalUserContext object


### PR DESCRIPTION
This change was mainly to work around problems with a custom shortcut for Star Wars: Dark Forces purchased from GOG. The name has a Registerted Sign (U+00AE) in it which would make the name fail to convert to ascii and cause the script to stop. The change seems to work fine for my other non-Steam app shortcuts as well.
